### PR TITLE
Option to not change the toggle's text

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All the following can be passed in an options object in the second parameter of 
 * `expandedToggleText` [`'less|fewer'`]: Text to show on toggle button when expanded (defaults to fewer when in count mode, or less when in height mode). Accepts empty strings
 * `collapsedToggleText` [`'more'`]: Text to show on toggle button when collapsed. Accepts empty strings
 * `toggleSelector`[`'button.o-expander__toggle'`]: Selector for expand/collapse toggle button. When using the default selector some styling, with an arrow icon, will come for free. If the selector matches more than one element they will all have the ability to expand/collapse the expander
-* `changeToggleText`[`true`]: If you would rather than toggle's text didn't change, set to false
+* `toggleState`[`'all|aria|none'`]: Do you want the epxander to update the button's text and `aria-pressed` attribute, just the aria attribute or neither (defaults to `all`)
 
 ## Events
 o-expander fires the following events, which always fire before any repainting/layout occurs

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ All the following can be passed in an options object in the second parameter of 
 * `expandedToggleText` [`'less|fewer'`]: Text to show on toggle button when expanded (defaults to fewer when in count mode, or less when in height mode). Accepts empty strings
 * `collapsedToggleText` [`'more'`]: Text to show on toggle button when collapsed. Accepts empty strings
 * `toggleSelector`[`'button.o-expander__toggle'`]: Selector for expand/collapse toggle button. When using the default selector some styling, with an arrow icon, will come for free. If the selector matches more than one element they will all have the ability to expand/collapse the expander
+* `changeToggleText`[`true`]: If you would rather than toggle's text didn't change, set to false
 
 ## Events
 o-expander fires the following events, which always fire before any repainting/layout occurs

--- a/demos/Variants.html
+++ b/demos/Variants.html
@@ -63,6 +63,29 @@
     </div>
     <button class="custom-toggle o--if-js"></button>
 </div>
+
+<div data-o-component="o-expander" class="o-expander items" data-o-expander-shrink-to="0" data-o-expander-count-selector="li" data-o-expander-toggle-state="none">
+    <h2>Don't change my button data</h2>
+    <ul class="o-expander__content" aria-expanded="true">
+        <li>item</li>
+        <li>item</li>
+        <li>item</li>
+        <li>item</li>
+    </ul>
+    <button class="o-expander__toggle o--if-js">This text ain't budging</button>
+</div>
+
+<div data-o-component="o-expander" class="o-expander items" data-o-expander-shrink-to="0" data-o-expander-count-selector="li" data-o-expander-toggle-state="aria">
+    <h2>Oh, OK. You can update the aria-pressed attribute</h2>
+    <ul class="o-expander__content" aria-expanded="true">
+        <li>item</li>
+        <li>item</li>
+        <li>item</li>
+        <li>item</li>
+    </ul>
+    <button class="o-expander__toggle o--if-js">But I still ain't budging<i></i></button>
+</div>
+
 <script src="/bundles/js?modules=o-expander:/demos/src/variants.js"></script>
 <script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
 </body>

--- a/demos/src/variants.mustache
+++ b/demos/src/variants.mustache
@@ -48,3 +48,25 @@
     </div>
     <button class="custom-toggle o--if-js"></button>
 </div>
+
+<div data-o-component="o-expander" class="o-expander items" data-o-expander-shrink-to="0" data-o-expander-count-selector="li" data-o-expander-toggle-state="none">
+    <h2>Don't change my button data</h2>
+    <ul class="o-expander__content" aria-expanded="true">
+        <li>item</li>
+        <li>item</li>
+        <li>item</li>
+        <li>item</li>
+    </ul>
+    <button class="o-expander__toggle o--if-js">This text ain't budging</button>
+</div>
+
+<div data-o-component="o-expander" class="o-expander items" data-o-expander-shrink-to="0" data-o-expander-count-selector="li" data-o-expander-toggle-state="aria">
+    <h2>Oh, OK. You can update the aria-pressed attribute</h2>
+    <ul class="o-expander__content" aria-expanded="true">
+        <li>item</li>
+        <li>item</li>
+        <li>item</li>
+        <li>item</li>
+    </ul>
+    <button class="o-expander__toggle o--if-js">But I still ain't budging<i></i></button>
+</div>

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ var Expander = function (el, opts) {
 	this.configure('expandedToggleText', this.opts.shrinkTo === 'height' ? 'less' : 'fewer');
 	this.configure('collapsedToggleText', 'more');
 	this.configure('toggleSelector', 'button.o-expander__toggle');
-	this.configure('changeToggleText', true);
+	this.configure('toggleState', 'all');
 
 
 	if (/^\d+$/.test(this.opts.shrinkTo)) {
@@ -121,30 +121,27 @@ Expander.prototype.displayState = function (isSilent) {
 	this.isCollapsed() ? this.collapse(isSilent) : this.expand(isSilent);
 };
 
-Expander.prototype.expand = function (isSilent) {
-	this.contentEl.setAttribute('aria-expanded', true);
-	this.toggles.forEach(function (toggle) {
-		if (this.opts.changeToggleText) {
-			toggle.innerHTML = this.opts.expandedToggleText + '<i></i>';
-		}
-		toggle.setAttribute('aria-pressed', '');
-	}.bind(this));
+var toggleExpander = function (state, isSilent) {
+	this.contentEl.setAttribute('aria-expanded', state === 'expand');
+	if (this.opts.toggleState !== 'none') {
+		this.toggles.forEach(function (toggle) {
+			if (this.opts.toggleState !== 'aria') {
+				toggle.innerHTML = this.opts[state === 'expand' ? 'expandedToggleText' : 'collapsedToggleText'] + '<i></i>';
+			}
+			toggle[state === 'expand' ? 'setAttribute' : 'removeAttribute']('aria-pressed', '');
+		}.bind(this));
+	}
 	if (!isSilent) {
-		this.emit('expand');
+		this.emit(state);
 	}
 };
 
+Expander.prototype.expand = function (isSilent) {
+	toggleExpander('expand', isSilent);
+};
+
 Expander.prototype.collapse = function (isSilent) {
-	this.contentEl.setAttribute('aria-expanded', false);
-	this.toggles.forEach(function (toggle) {
-		if (this.opts.changeToggleText) {
-			toggle.innerHTML = this.opts.collapsedToggleText + '<i></i>';
-		}
-		toggle.removeAttribute('aria-pressed');
-	}.bind(this));
-	if (!isSilent) {
-		this.emit('collapse');
-	}
+	toggleExpander('collapse', isSilent);
 };
 
 Expander.prototype.emit = function (name) {

--- a/main.js
+++ b/main.js
@@ -137,11 +137,11 @@ var toggleExpander = function (state, isSilent) {
 };
 
 Expander.prototype.expand = function (isSilent) {
-	toggleExpander('expand', isSilent);
+	toggleExpander.call(this, 'expand', isSilent);
 };
 
 Expander.prototype.collapse = function (isSilent) {
-	toggleExpander('collapse', isSilent);
+	toggleExpander.call(this, 'collapse', isSilent);
 };
 
 Expander.prototype.emit = function (name) {

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ var Expander = function (el, opts) {
 	this.configure('expandedToggleText', this.opts.shrinkTo === 'height' ? 'less' : 'fewer');
 	this.configure('collapsedToggleText', 'more');
 	this.configure('toggleSelector', 'button.o-expander__toggle');
+	this.configure('changeToggleText', true);
 
 
 	if (/^\d+$/.test(this.opts.shrinkTo)) {
@@ -123,7 +124,9 @@ Expander.prototype.displayState = function (isSilent) {
 Expander.prototype.expand = function (isSilent) {
 	this.contentEl.setAttribute('aria-expanded', true);
 	this.toggles.forEach(function (toggle) {
-		toggle.innerHTML = this.opts.expandedToggleText + '<i></i>';
+		if (this.opts.changeToggleText) {
+			toggle.innerHTML = this.opts.expandedToggleText + '<i></i>';
+		}
 		toggle.setAttribute('aria-pressed', '');
 	}.bind(this));
 	if (!isSilent) {
@@ -134,7 +137,9 @@ Expander.prototype.expand = function (isSilent) {
 Expander.prototype.collapse = function (isSilent) {
 	this.contentEl.setAttribute('aria-expanded', false);
 	this.toggles.forEach(function (toggle) {
-		toggle.innerHTML = this.opts.collapsedToggleText + '<i></i>';
+		if (this.opts.changeToggleText) {
+			toggle.innerHTML = this.opts.collapsedToggleText + '<i></i>';
+		}
 		toggle.removeAttribute('aria-pressed');
 	}.bind(this));
 	if (!isSilent) {


### PR DESCRIPTION
Use case, multiple buttons control a single expander, each button has different text (which doesn't change on expand/collapse)