### PR TITLE
Use o-fonts 2.0.0-beta.4+

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "o-viewport": ">=1.2.0 <3",
     "o-ft-icons": "^2.3.4",
-    "o-fonts": "^1.6.4",
+    "o-fonts": "^2.0.0",
     "o-colors": ">=2.5.0 <4"
   }
 }


### PR DESCRIPTION
(Next is already using o-fonts v2, so this’ll help us clean up some Bower
resolutions.)