### PR TITLE
Switch to using SVG mixin from o-ft-icons v3.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "o-viewport": ">=1.2.0 <3",
-    "o-ft-icons": ">=2.3.4 <4",
+    "o-ft-icons": ">=3.2.0 <5",
     "o-colors": ">=2.5.0 <4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "o-viewport": ">=1.2.0 <3",
-    "o-ft-icons": ">=3.2.0 <5",
+    "o-ft-icons": ">=3.2.1 <5",
     "o-colors": ">=2.5.0 <4"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -36,14 +36,14 @@ $o-expander-is-silent: true !default;
 	border: 0;
 
 	i {
-		@include oFtIconsBaseIconStyles();
 		@include oFtIconsGetSvg('arrow-down', oColorsGetColorFor(expander-icon, text), 12, 12);
 		display: inline-block;
+		vertical-align: middle;
 		padding: 0 6px;
 	}
 
 	&[aria-expanded="true"] i {
-		@include oFtIconsGetSvg('arrow-up', oColorsGetColorFor(expander-icon, text), 12, 12);
+		@include oFtIconsGetSvg('arrow-up', oColorsGetColorFor(expander-icon, text), 12, $apply-base-styles:false);
 	}
 
 	&:hover {

--- a/main.scss
+++ b/main.scss
@@ -38,7 +38,6 @@ $o-expander-is-silent: true !default;
 	i {
 		@include oFtIconsGetSvg('arrow-down', oColorsGetColorFor(expander-icon, text), 12, 12);
 		display: inline-block;
-		vertical-align: middle;
 		padding: 0 6px;
 	}
 

--- a/main.scss
+++ b/main.scss
@@ -37,21 +37,13 @@ $o-expander-is-silent: true !default;
 
 	i {
 		@include oFtIconsBaseIconStyles();
-		@include oColorsFor(expander-icon, text);
+		@include oFtIconsGetSvg('arrow-down', oColorsGetColorFor(expander-icon, text), 12, 12);
 		display: inline-block;
 		padding: 0 6px;
-		box-sizing: border-box;
 	}
 
-	i,
 	&[aria-expanded="true"] i {
-		@extend %o-ft-icons-icon--arrow-up;
-	}
-
-	// temporary higher specicifity while having to work with the selector order
-	// imposed by using @extend. Eventually with mixins it won't be needed
-	[data-o-expander-js] & i {
-		@extend %o-ft-icons-icon--arrow-down;
+		@include oFtIconsGetSvg('arrow-up', oColorsGetColorFor(expander-icon, text), 12, 12);
 	}
 
 	&:hover {


### PR DESCRIPTION
Switches the expander icon to use the `oFtIconsGetSvg` mixin.

Removes specificity on the down state, now that `@include` is being used instead of `@extend`