### PR TITLE
Update demos

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -24,7 +24,6 @@
 			"description": "Simple use cases",
 			"template": "demos/src/simple.mustache",
 			"js": "demos/src/demo.js",
-			"expanded": true,
 			"description": "Simple use cases"
 		},
 		{
@@ -32,7 +31,7 @@
 			"description": "More advanced configurations of the module",
 			"template": "demos/src/variants.mustache",
 			"js": "demos/src/variants.js",
-			"expanded": false,
+			"hidden": true,
 			"description": "More advanced configurations of the module"
 		}
 	]


### PR DESCRIPTION
Hide the `variants` demo. The demo is really long, containing various ways the module can be used which means there's only portions of the HTML that can be copied from the demo. It would be better if demos could be copied completely and provide a working solution without much configuration instead of having to pick the correct part of the HTML to copy. Hidden for now so it can be removed at a later date or split out into separate demos.

Removes the deprecated `expanded` property.