### PR TITLE
update o-icons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
   "dependencies": {
     "o-viewport": ">=1.2.0 <3",
     "o-colors": ">=2.5.0 <4",
-    "o-icons": "^4.1.0"
+    "o-icons": "^4.4.2"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -36,19 +36,15 @@ $o-expander-is-silent: true !default;
 	border: 0;
 
 	i {
-		@include oIconsGetIcon('arrow-down', oColorsGetColorFor(expander-icon, text), 12, 12);
-		display: inline-block;
-		padding: 0 6px;
-
-		// Preload active icons
-		&:before {
-			@include oIconsGetIcon('arrow-up', oColorsGetColorFor(expander-icon, text), 12, $apply-base-styles:false);
-			content: '';
-		}
+		@include oIconsGetIcon('arrow-down', oColorsGetColorFor(expander-icon, text), 15, 15, $iconset-version: 1);
+		padding: 0 3px;
+		vertical-align: middle;
 	}
 
 	&[aria-expanded="true"] i {
-		@include oIconsGetIcon('arrow-up', oColorsGetColorFor(expander-icon, text), 12, $apply-base-styles:false);
+		// Rotate the icon rather than downloading another one
+		// I call this the "Matt Hinchliffe manouvre"
+		transform: rotate(180deg);
 	}
 
 	&:hover {


### PR DESCRIPTION
A new version of o-icons is here!
This commit:
- Bumps the version to the latest minor
- Adjusts the sizing (the new icons are a bit smaller/have a different
amount of padding)
- removes the second icon download as we only need to rotate the up
arrow to get the down arrow, not download it