### PR TITLE
Widen o-icons semver range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
   "dependencies": {
     "o-viewport": ">=1.2.0 <3",
     "o-colors": ">=2.5.0 <4",
-    "o-icons": "^4.4.2"
+    "o-icons": ">=4.4.2 <6"
   }
 }


### PR DESCRIPTION
So that projects can choose to migrate o-icons to v5 or leave it,
this commit widens the accepted semver range for o-icons to anything
above 4.4.2 but less than the next major (which would be 6)