### PR TITLE
Remove o-colors dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
   ],
   "dependencies": {
     "o-viewport": ">=1.2.0 <4",
-    "o-colors": ">=2.5.0 <4",
     "o-icons": ">=4.4.2 <6"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,10 +1,5 @@
 @import "o-icons/main";
 
-@import "o-colors/main";
-
-@include oColorsSetUseCase(expander-text, text, 'black');
-@include oColorsSetUseCase(expander-icon, text, 'grey-tint2');
-
 $o-expander-is-silent: true !default;
 
 @mixin oExpanderContent {
@@ -23,8 +18,8 @@ $o-expander-is-silent: true !default;
 	}
 }
 
-@mixin oExpanderToggle($root-class-name: o-expander) {
-	@include oColorsFor(expander-text, text);
+@mixin oExpanderToggle($root-class-name: o-expander, $font-color: #000000, $icon-color: #000000) {
+	color: $font-color;
 	font-weight: normal;
 	font-size: 12px;
 	margin: 0;
@@ -35,7 +30,7 @@ $o-expander-is-silent: true !default;
 	text-decoration: none;
 
 	i {
-		@include oIconsGetIcon('arrow-down', oColorsGetColorFor(expander-icon, text), 15, 15, $iconset-version: 1);
+		@include oIconsGetIcon('arrow-down', $icon-color, 15, 15, $iconset-version: 1);
 		padding: 0 3px;
 		vertical-align: middle;
 	}


### PR DESCRIPTION
This commit removes the o-colors dependency, replacing it with a default
color (black) for the down arrow icon which is what it was used for.

Since this module is a utility not a masterbrand component, it shouldn't
have dependencies on things like o-colors but instead be styled by the
consuming component.

We have a few users of o-expander from the build service. For them, this will change the icon color from grey to black. I think this is probably not going to break anything for anyone so it is my intention to release this as a minor.