### PR TITLE
Add event listener to allow an external component to collapse the expander

### DIFF
--- a/main.js
+++ b/main.js
@@ -114,6 +114,9 @@ const Expander = function (el, opts) {
 	this.toggles.forEach(toggle => {
 		toggle.addEventListener('click', () => this.invertState());
 	});
+	this.el.addEventListener('oExpander.forceCollapse', () => {
+		this.collapse();
+	});
 	this.el.setAttribute('data-o-expander-js', '');
 	this.apply(true);
 	this.emit('init');


### PR DESCRIPTION
Work-in-progress, just for feedback.
I couldn't see an existing way for an external component to request the expander to collapse. 

A use case might be, the expander contains a form which, when saved, collapses the panel:

![image](https://user-images.githubusercontent.com/471250/36668730-1f5e4b16-1aea-11e8-8eea-73a1e83e3ca3.png)

Is an acceptable approach to fire an event on the component boundary?