### PR TITLE
Add a primary mixin.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,7 +10,11 @@ The data attribute `data-o-expander-js` has been replaced with the class `o-expa
 
 Expanders with the `shrinkTo` (`data-shrink-to`) option set to a number, to toggle a collapsing list, will now have `aria-hidden` set on collapsed items. No changes should be required.
 
-### Removed JavaScript Methods
+### Sass
+
+The Sass mixins `oExpanderToggle` and `oExpanderContent` have been removed. Instead use `oExpander` to include all `o-expander` CSS. Classnames are no longer customisable with `oExpander`, update your markup and javascript to use `o-expander` classes instead. If this is not possible consider creating a [Custom Expander](./README.md#custom-expander) instead.
+
+### JavaScript
 
 The following functions are removed or now private, ensure your project doesn't call them:
 - `toggleExpander` and `displayState`: use `toggle`, `collapse`, or `expand` methods instead.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Accessible, content-aware component for expanding and collapsing content.
 
 - [Markup](#markup)
-- [JavaScript](#javascript)
 - [Sass](#sass)
+- [JavaScript](#javascript)
 - [Options](#options)
 - [Contact](#contact)
 - [Licence](#licence)
@@ -18,6 +18,18 @@ The  `o-expander` component has a content element `o-expander__content` (the DOM
 ```html
 <div data-o-component="o-expander" class="o-expander">
     <div class="o-expander__content">
+      <!-- Some content to expand and collapse. -->
+    </div>
+    <button class="o-expander__toggle">Toggle Content</button>
+</div>
+```
+
+By default o-expander will collapse content on initialisation. To prevent this add the class `.o-expander__content--expanded`.
+
+```diff
+<div data-o-component="o-expander" class="o-expander">
+-    <div class="o-expander__content">
++    <div class="o-expander__content o-expander__content--expanded">
       <!-- Some content to expand and collapse. -->
     </div>
     <button class="o-expander__toggle">Toggle Content</button>
@@ -133,6 +145,19 @@ If you would not like toggle text to be updated set `data-o-expander-collapsed-t
 	</div>
 ```
 
+## Sass
+
+
+Default expander styles hide the toggle until the expander is initialised successfully, so no content is obscured if JavaScript fails. When toggled the expander hides and shows content immediately. To include all `o-expander` CSS use the `oExpander` mixin.
+
+```scss
+  @include oExpander();
+```
+If using the height expander, also set your `max-height`. See [Height Expander](#height-expander) for an example.
+
+_For animation and other more complex styles don't include opinionated o-expander CSS. Instead create a [custom expander](#custom-expander) with totally custom styles._
+
+
 ## JavaScript
 
 No JavaScript will run automatically unless you are using the Build Service. You must either construct an `o-expander` object or fire an o.DOMContentLoaded event, which `o-expander` listens for.
@@ -207,24 +232,6 @@ o-expander fires the following events, which always fire before any repainting/l
   * `oExpander.init` - fires when the expander has initialised
   * `oExpander.expand` - fires when the expander expands
   * `oExpander.collapse` - fires when the expander collapses
-
-## Sass
-
-  * If you want to use the default classes, turn silent mode off before importing it: `$o-expander-is-silent: false;`
-  * By default o-expander will collapse content on initialisation. To prevent this add the class `.o-expander__content--expanded`
-  * Maximum height (when collapsed) should be set using css. Be mindful that when js doesn't run you may want to default to showing all the content e.g.
-
-    ```scss
-    .o--if-js .o-expander__content { // ensures all content is shown when js doesn't run
-        max-height: 50px;
-    }
-
-    .o-expander__content { // collapses content when js doesn't run
-        max-height: 50px;
-    }
-    ```
-
-  * Animation and other fancy behaviour can be added using css and by listening to the events outlined above.
 
 ## Migration
 

--- a/demos/src/collapsing-height.mustache
+++ b/demos/src/collapsing-height.mustache
@@ -1,6 +1,6 @@
 <div data-o-component="o-expander" class="o-expander" data-o-expander-shrink-to="height" data-o-expander-collapsed-toggle-text="Toggle: Click To Expand" data-o-expander-expanded-toggle-text="Toggle: Click To Collapse">
 	<div class="o-expander__content">
-		In this "collapsing height" demo we have set a maximum height and hidden overflow for the expander with custom demo CSS. The toggle will remain hidden unless this content overflows the expander. In this example it will overflow when viewed within a small viewport. Open this demo in a new tab and resize the window to see the toggle appear/disappear in a content-aware manner.
+		In this "collapsing height" demo we have set a maximum height to the expander's content element with custom demo CSS. The toggle will remain hidden unless this content overflows the expander. In this example it will overflow when viewed within a small viewport. Open this demo in a new tab and resize the window to see the toggle appear/disappear in a content-aware manner.
 	</div>
 	<button class="o-expander__toggle">Toggle</button>
 </div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,11 +1,7 @@
-[data-o-expander-shrink-to="height"] .o-expander__content {
-	max-height: 72px;
-	overflow: hidden;
-}
-
-.demo-alert {
-	color: red;
-}
-
-$o-expander-is-silent: false;
 @import "./../../main";
+
+@include oExpander();
+
+.o-expander--initialized[data-o-expander-shrink-to="height"] .o-expander__content {
+	max-height: 72px;
+}

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,10 +1,8 @@
 <div data-o-component="o-expander" class="o-expander" data-o-expander-shrink-to="height" data-o-expander-collapsed-toggle-text="Toggle: Click To Expand" data-o-expander-expanded-toggle-text="Toggle: Click To Collapse">
 	<div class="o-expander__content">
-		In this "collapsing height" demo we have set a maximum height and hidden overflow for the expander with custom demo CSS. The toggle will remain hidden unless this content overflows the expander. In this example it will overflow when viewed within a small viewport. Open this demo in a new tab and resize the window to see the toggle appear/disappear in a content-aware manner.
+		In this "collapsing height" demo we have set a maximum height to the expander's content element with custom demo CSS. The toggle will remain hidden unless this content overflows the expander. In this example it will overflow when viewed within a small viewport. Open this demo in a new tab and resize the window to see the toggle appear/disappear in a content-aware manner.
 	</div>
-	<button class="o-expander__toggle">
-		Toggle
-	</button>
+	<button class="o-expander__toggle">Toggle</button>
 </div>
 
 <div data-o-component="o-expander" class="o-expander" data-o-expander-shrink-to="2">

--- a/main.scss
+++ b/main.scss
@@ -1,63 +1,77 @@
 @import "o-icons/main";
+@import 'src/scss/variables';
 
-$o-expander-is-silent: true !default;
-
-@mixin oExpanderContent {
-	&[aria-hidden="true"] {
+@mixin oExpander() {
+	// Hide content when aria-hidden is applied.
+	.o-expander__content[aria-hidden="true"] {
 		display: none;
 	}
 
-	// Needs extra specificity
-	&#{&}--expanded {
-		max-height: none;
+	// Remove max-height from content when expanded.
+	// This must override the user set max-height, so use `!important` to
+	// guarantee higher specificity. Users may use the `createCustom` method
+	// and totally custom CSS for an expander with different behaviour.
+	.o-expander__content--expanded {
+		max-height: none !important;
 	}
 
-	// The class is added via JS, so it can use the default name
-	&--collapsed .o-expander__collapsible-item {
+	// Hide overflow when collapsed.
+	.o-expander__content--collapsed {
+		overflow: hidden;
+	}
+
+	// Hide collapsible-item within the content expander content when
+	// it is collapsed.
+	.o-expander__content--collapsed .o-expander__collapsible-item {
 		display: none;
 	}
-}
 
-@mixin oExpanderToggle($root-class-name: o-expander, $font-color: #000000, $icon-color: #000000) {
-	color: $font-color;
-	font-weight: normal;
-	font-size: 12px;
-	margin: 0;
-	padding: 0;
-	background: none;
-	cursor: pointer;
-	border: 0;
-	text-decoration: none;
-
-	i {
-		@include oIconsGetIcon('arrow-down', $icon-color, 15, 15, $iconset-version: 1);
-		padding: 0 3px;
-		vertical-align: middle;
-	}
-
-	&[aria-expanded="true"] i {
-		// Rotate the icon rather than downloading another one
-		// I call this the "Matt Hinchliffe manouvre"
-		transform: rotate(180deg);
-	}
-
-	&:hover {
+	// Style the default expander toggle.
+	.o-expander__toggle {
+		$font-color: #000000;
+		$icon-color: #000000;
+		color: $font-color;
+		font-weight: normal;
+		font-size: 12px;
+		margin: 0;
+		padding: 0;
+		background: none;
+		cursor: pointer;
+		border: 0;
 		text-decoration: none;
+
+		&:hover {
+			text-decoration: none;
+		}
+
+		&:after {
+			content: '';
+			@include oIconsGetIcon('arrow-down', $icon-color, 15, 15, $iconset-version: 1);
+			padding: 0 3px;
+			vertical-align: middle;
+		}
+
+		&[aria-expanded="true"]:after {
+			// Rotate the icon rather than downloading another one
+			// I call this the "Matt Hinchliffe manouvre"
+			transform: rotate(180deg);
+		}
 	}
 
-	.#{$root-class-name}--inactive & {
+	// Hide the toggle by default, or when the expander is inactive.
+	.o-expander__toggle,
+	.o-expander--inactive .o-expander__toggle {
 		display: none;
+	}
+
+	// Show the toggle when the expander is initialised.
+	.o-expander--initialized .o-expander__toggle {
+		display: inline-block;
 	}
 }
 
 @if ($o-expander-is-silent == false) {
-	.o-expander__content {
-		@include oExpanderContent;
-	}
-
-	.o-expander__toggle {
-		@include oExpanderToggle;
-	}
+	@include oExpander();
 
 	// Don't output twice
 	$o-expander-is-silent: true !global;

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,7 @@
 @import "o-icons/main";
 @import 'src/scss/variables';
 
+/// @outputs All o-expander CSS, including the expander content area and toggle.
 @mixin oExpander() {
 	// Hide content when aria-hidden is applied.
 	.o-expander__content[aria-hidden="true"] {

--- a/main.scss
+++ b/main.scss
@@ -12,7 +12,7 @@
 	// guarantee higher specificity. Users may use the `createCustom` method
 	// and totally custom CSS for an expander with different behaviour.
 	.o-expander__content--expanded {
-		max-height: none !important;
+		max-height: none !important; //sass-lint:disable-line no-important
 	}
 
 	// Hide overflow when collapsed.
@@ -45,8 +45,8 @@
 		}
 
 		&:after {
-			content: '';
 			@include oIconsGetIcon('arrow-down', $icon-color, 15, 15, $iconset-version: 1);
+			content: '';
 			padding: 0 3px;
 			vertical-align: middle;
 		}

--- a/src/js/expander-utility.js
+++ b/src/js/expander-utility.js
@@ -326,7 +326,7 @@ class ExpanderUtility {
 				if (this.options.toggleState !== 'aria') {
 					toggle.innerHTML = (state === 'expand' ?
 						this.options.expandedToggleText :
-						this.options.collapsedToggleText) + '<i></i>';
+						this.options.collapsedToggleText);
 				}
 				toggle.setAttribute('aria-expanded', state === 'expand' ? 'true' : 'false');
 			});

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,0 +1,1 @@
+$o-expander-is-silent: true !default;


### PR DESCRIPTION
I've made some changes to the CSS itself, as well as rearranging.
Including but not limited to:
- toggles are hidden until the expander is initalised using o-exapnder 
CSS, rather than relying on the user to add `o--if-js`.
- the toggle icon is included as a pseudo element
- `!important` is used for the max height