### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,5 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
+/* eslint-env mocha */
+/* global proclaim */
+
 import * as fixtures from './helpers/fixtures';
 
 import Expander from './../main';

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -1,5 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
+/* eslint-env mocha */
+/* global proclaim */
+
 import * as fixtures from './helpers/fixtures';
 
 import Expander from './../main';

--- a/test/initialization.test.js
+++ b/test/initialization.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import * as fixtures from './helpers/fixtures';
 
 import Expander from './../main';

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import * as fixtures from './helpers/fixtures';
 
 import Expander from './../main';


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.