### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Expander from './src/js/expander';
+import Expander from './src/js/expander.js';
 
 const constructAll = function () {
 	Expander.init();

--- a/src/js/expander.js
+++ b/src/js/expander.js
@@ -1,4 +1,4 @@
-import ExpanderUtility from './expander-utility';
+import ExpanderUtility from './expander-utility.js';
 
 class Expander extends ExpanderUtility {
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import Expander from './../main';
+import Expander from './../main.js';
 
 describe("Expander", () => {
 

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import Expander from './../main';
+import Expander from './../main.js';
 
 describe("Expander", () => {
 	describe("createCustom", () => {

--- a/test/initialization.test.js
+++ b/test/initialization.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import Expander from './../main';
+import Expander from './../main.js';
 
 describe("Expander", () => {
 	it('is defined', () => {

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import Expander from './../main';
+import Expander from './../main.js';
 
 describe("Expander", () => {
 	let collapseSpy;


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing