### PR TITLE
Add summary/details keywords

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -1,6 +1,6 @@
 {
 	"description": "Content-aware helper for expanding and collapsing content or lists.",
-	"keywords": [ "expand", "content", "more", "less" ],
+	"keywords": [ "expand", "content", "more", "less", "summary", "details" ],
 	"origamiVersion": 1,
 	"origamiCategory": "primitives",
 	"origamiType": "module",


### PR DESCRIPTION
Someone may be thinking of the `summary`/`details` element when
looking for a component like `o-expander`