### PR TITLE
Make getDataAttributes ignore data attributes which are not in the component's namespace

### DIFF
--- a/src/js/expander.js
+++ b/src/js/expander.js
@@ -77,8 +77,8 @@ class Expander extends ExpanderUtility {
 			return {};
 		}
 		return Object.keys(oExpanderElement.dataset).reduce((options, key) => {
-			// Ignore data-o-component
-			if (key === 'oComponent') {
+			// Ignore keys which are not in the component's namespace
+			if (!key.match(/^oExpander(\w)(\w+)$/)) {
 				return options;
 			}
 			// Build a concise key and get the option value


### PR DESCRIPTION
This keeps the method aligned with the definition in the component template https://github.com/Financial-Times/create-origami-component/pull/214